### PR TITLE
Fix documentation for minimum UID parameter

### DIFF
--- a/nss_mapuser.5
+++ b/nss_mapuser.5
@@ -27,7 +27,7 @@ fields from the
 configuration file are always skipped, as are any names starting with
 .BR tacacs[0-9] .
 .TP
-.I min_uid=NUMBER
+.I map_min_uid=NUMBER
 UID's passed to the NSS mapuid plugin getpwuid() entry point that are below this value
 cause an immediate NOTFOUND status to be returned.  This reduces
 overhead for the standard local user accounts.

--- a/nss_mapuser.conf
+++ b/nss_mapuser.conf
@@ -12,12 +12,12 @@
 # if set, errors and other issues are logged with syslog
 # debug=1
 
-# min_uid is the minimum uid to lookup.  Setting this to 0
+# map_min_uid is the minimum uid to lookup.  Setting this to 0
 # means uid 0 (root) is never looked up, good for robustness and performance
 # Cumulus Linux ships with it set to 1001, so we never lookup system
 # users, or the standard "cumulus" account.  You may want to change this
 # to the value of the radius_user account.
-#min_uid=1001
+#map_min_uid=1001
 
 # This is a comma separated list of usernames that are never mapped
 # because they are standard accounts.  They cause an early not found


### PR DESCRIPTION
Minimum UID parameter is `min_uid` in documentation but `map_min_uid` in configuration parsing function.