### PR TITLE
nss: T4943: Fixed `min_nss` option parser

### DIFF
--- a/map_common.c
+++ b/map_common.c
@@ -141,7 +141,7 @@ int nss_mapuser_config(int *errnop, const char *lname)
 		} else if (!strncmp(lbuf, "mapped_priv_user=", 17)) {
 			/*  the user we are mapping to */
 			mapped_priv_user = strdup(lbuf + 17);
-		} else if (!strncmp(lbuf, "map_min_uid=", 8)) {
+		} else if (!strncmp(lbuf, "min_uid=", 8)) {
 			/*
 			 * Don't lookup uids that are local, typically set to either
 			 * 0 or smallest always local user's uid


### PR DESCRIPTION
It was already done once in 9d328a6d838d1d3675b5def62c577c5eb322d103 but the config option name was changed and our fixes reverted after the update to 1.1.0-cl3u3 in 2ded63a0e6748018dada646691843462797cc7fc